### PR TITLE
Lookup for latest tag in repo

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -173,7 +173,7 @@ lookup_latest_tag() {
     git fetch --tags > /dev/null 2>&1
 
     if ! git describe --tags --abbrev=0 2> /dev/null; then
-        git rev-list --max-parents=0 --first-parent HEAD
+        git rev-list --tags --max-count=1
     fi
 }
 


### PR DESCRIPTION
lookup_latest_tag returns mistakenly first commit in repo instead of last tag in repo.

Signed-off-by: Petr Řehoř <rx@rx.cz>