### PR TITLE
Allow installing chart-releaser from Git

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -209,7 +209,7 @@ package_chart() {
     local chart="$1"
 
     echo "Packaging chart '$chart'..."
-    helm package "$chart" --destination .cr-release-packages --dependency-update --save=false
+    helm package "$chart" --destination .cr-release-packages --dependency-update
 }
 
 release_charts() {

--- a/cr.sh
+++ b/cr.sh
@@ -164,9 +164,21 @@ parse_command_line() {
 install_chart_releaser() {
     echo "Installing chart-releaser..."
 
-    curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$version/chart-releaser_${version#v}_linux_amd64.tar.gz"
-    tar -xzf cr.tar.gz
-    sudo mv cr /usr/local/bin/cr
+    if [[ ! -z "${CHART_RELEASE_COMMIT_HASH}" ]]
+    then
+        echo "Installing chart-releaser from GitHub."
+        git clone https://github.com/helm/chart-releaser
+        cd chart-releaser
+        git checkout ${CHART_RELEASE_COMMIT_HASH}
+        go mod download
+        go install ./...
+        export PATH=$PATH:$HOME/go/bin
+        cd ..
+    else
+        curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$version/chart-releaser_${version#v}_linux_amd64.tar.gz"
+        tar -xzf cr.tar.gz
+        sudo mv cr /usr/local/bin/cr
+    fi
 }
 
 lookup_latest_tag() {


### PR DESCRIPTION
Motivation:
- Release a Helm 3 package 
- there is not yet a released version of `chart-releaser`, but the Helm v3 compatibility is already on master. Hence, we can temporarily install from GitHub directly.

Change:

- if an env variable `CHART_RELEASE_COMMIT_HASH` is specified, then the `chart-releaser` is installed from GitHub using the given commit hash 
- remove `--save` option since it's incompatible with Helm v3 