### PR TITLE
Use provided GITHUB_TOKEN instead of custom PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 ### Pre-requisites
 
 1. A GitHub repo containing a directory with your Helm charts (eg: `/charts`)
-1. A GitHub project [Secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) named `CR_TOKEN` with the value of a GitHub [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token)
-    * The token must have `repo` scope
-    * The token's user must have write access to the project
-    * To mitigate risk you may wish to limit the token to a single project by creating a [machine user](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users)
-    * Please note the personal access token is required because of an [Actions bug](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31266/highlight/true#M743), and will hopefully be unnecessary in the future
 1. Create a workflow `.yml` file in your `.github/workflows` directory. An [example workflow](#example-workflow) is available below. 
   For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.1
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
 This uses [@helm/chart-releaser-action](https://www.github.com/helm/chart-releaser-action) to turn your GitHub project into a self-hosted Helm chart repo.

--- a/cr.sh
+++ b/cr.sh
@@ -20,8 +20,6 @@ set -o pipefail
 
 DEFAULT_CHART_RELEASER_VERSION=v1.0.0-beta.1
 
-: "${CR_TOKEN:?Environment variable CR_TOKEN must be set}"
-
 show_help() {
 cat << EOF
 Usage: $(basename "$0") <options>
@@ -239,7 +237,7 @@ update_index() {
     git add index.yaml
     git commit --message="Update index.yaml" --signoff
 
-    local repo_url="https://x-access-token:$CR_TOKEN@github.com/$owner/$repo"
+    local repo_url="https://x-access-token:$GITHUB_TOKEN@github.com/$owner/$repo"
     git push "$repo_url" gh-pages
 
     popd > /dev/null

--- a/cr.sh
+++ b/cr.sh
@@ -20,6 +20,8 @@ set -o pipefail
 
 DEFAULT_CHART_RELEASER_VERSION=v1.0.0-beta.1
 
+: "${CR_TOKEN:?Environment variable CR_TOKEN must be set}"
+
 show_help() {
 cat << EOF
 Usage: $(basename "$0") <options>

--- a/cr.sh
+++ b/cr.sh
@@ -237,7 +237,7 @@ update_index() {
     git add index.yaml
     git commit --message="Update index.yaml" --signoff
 
-    local repo_url="https://x-access-token:$GITHUB_TOKEN@github.com/$owner/$repo"
+    local repo_url="https://x-access-token:$CR_TOKEN@github.com/$owner/$repo"
     git push "$repo_url" gh-pages
 
     popd > /dev/null


### PR DESCRIPTION
Per the issue linked in the README, `CR_TOKEN` should no longer be necessary: https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31283/highlight/true#M751

fixes: #28 