### PR TITLE
Add index_md_path option to copy index.md path based on any file in the repository

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   charts_repo_url:
     description: "The GitHub Pages URL to the charts repo (default: https://<owner>.github.io/<repo>)"
     required: true
+  index_md_path:
+    description: "If set and file exists, copies <index_md.path> to GitHub Pages index.md (path should relative to repo root)"
+    required: false
 runs:
   using: "node12"
   main: "main.js"

--- a/main.sh
+++ b/main.sh
@@ -35,6 +35,10 @@ main() {
         args+=(--charts-repo-url "${INPUT_CHARTS_REPO_URL}")
     fi
 
+    if [[ -n "${INPUT_INDEX_MD_PATH:-}" ]]; then
+        args+=(--index-md-path "${INPUT_INDEX_MD_PATH}")
+    fi
+
     "$SCRIPT_DIR/cr.sh" "${args[@]}"
 }
 


### PR DESCRIPTION
Add option to publish a file (typically `README.md`) to the GH Pages, allowing to easily display a homepage on Helm charts URL.