### PR TITLE
Bump chart-releaser to v1.0.0 and prep chart-releaser-action for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
-- `version`: The chart-releaser version to use (default: v1.0.0-beta.1)
+- `version`: The chart-releaser version to use (default: v1.0.0)
 - `charts_dir`: The charts directory
 - `charts_repo_url`: The GitHub Pages URL to the charts repo (default: `https://<owner>.github.io/<project>`)
 
@@ -44,7 +44,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.1
+        uses: helm/chart-releaser-action@v1.0.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: anchor
 inputs:
   version:
-    description: "The chart-releaser version to use (default: v1.0.0-beta.1)"
+    description: "The chart-releaser version to use (default: v1.0.0)"
   charts_dir:
     description: The charts directory
     default: charts

--- a/cr.sh
+++ b/cr.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_CHART_RELEASER_VERSION=v1.0.0-beta.1
+DEFAULT_CHART_RELEASER_VERSION=v1.0.0
 
 : "${CR_TOKEN:?Environment variable CR_TOKEN must be set}"
 
@@ -27,7 +27,7 @@ cat << EOF
 Usage: $(basename "$0") <options>
 
     -h, --help               Display help
-    -v, --version            The chart-releaser version to use (default: v1.0.0-beta.1)"
+    -v, --version            The chart-releaser version to use (default: v1.0.0)"
     -d, --charts-dir         The charts directory (defaut: charts)
     -u, --charts-repo-url    The GitHub Pages URL to the charts repo (default: https://<owner>.github.io/<repo>)
     -o, --owner              The repo owner


### PR DESCRIPTION
These coincidentally are both ready for v1.0.0 (not that the action and cr will normally be the same version, but after this PR they will be)

Signed-off-by: Scott Rigby <scott@r6by.com>