### PR TITLE
Tag release with commit hash of the tip of current branch

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -218,7 +218,7 @@ package_chart() {
 
 release_charts() {
     echo 'Releasing charts...'
-    cr upload -o "$owner" -r "$repo"
+    cr upload -o "$owner" -r "$repo" -c "$(git rev-parse HEAD)"
 }
 
 update_index() {


### PR DESCRIPTION
At present, the tip of the default branch is tagged with the release instead of the branch target for release. This is not ideal if we want to make releases out of non-default branches. Use the current commit ID as the input when invoking `cr upload` so that the releases are tagged correctly.