### PR TITLE
Support sub chart dir

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -203,7 +203,7 @@ lookup_changed_charts() {
     if [[ "$charts_dir" == '.' ]]; then
         fields='1'
     else
-        fields='1,2'
+        fields='1-'
     fi
 
     cut -d '/' -f "$fields" <<< "$changed_files" | uniq | filter_charts


### PR DESCRIPTION
## Why?

- This change in PR will bring sub-directory support for `charts_dir`. Let's go through this example:

```
.
├── ops
│   ├── helm
│   │   ├── .helmignore
│   │   ├── chart1
│   │   ├── chart2
│   │   ├── chart3
│   │   ├── chart4
│   │   └── chart5
```
So, the `charts_dir` would be `ops/helm`

  - Before:
  ```bash
  cut -d '/' -f "1,2" <<< "ops/helm/chart1" ## -----> ops/helm --> no chart found
  ```

  - After:
  ```bash
  cut -d '/' -f "1-" <<< "ops/helm/chart1" ## -----> ops/helm/chart1 --> chart found
  ```


Signed-off-by: Tommy Nguyen <tuannvm@hotmail.com>