### PR TITLE
Fix charts_dir depth

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -225,7 +225,7 @@ lookup_changed_charts() {
     local changed_files
     changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
 
-    local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | wc -l) + 1 ))
+    local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | wc -l) ))
     local fields="1-${depth}"
 
     cut -d '/' -f "$fields" <<< "$changed_files" | uniq | filter_charts


### PR DESCRIPTION
A tiny fix to make charts_dir works again with the current working dir.
Related to: #61 