### PR TITLE
Set CRA config using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `charts_dir`: The charts directory
 - `charts_repo_url`: The GitHub Pages URL to the charts repo (default: `https://<owner>.github.io/<project>`)
 
+### Configuration
+
+All command-line flags can also be set via environment variables or config file.
+Environment variables must be prefixed with `CRA_` and underscores must be used instead of hyphens.
+
+So `--owner` will be `CRA_OWNER`.
+
 ### Example Workflow
 
 Create a workflow (eg: `.github/workflows/release.yml`):

--- a/cr.sh
+++ b/cr.sh
@@ -35,12 +35,12 @@ EOF
 }
 
 main() {
-    local version="$DEFAULT_CHART_RELEASER_VERSION"
-    local config=
-    local charts_dir=charts
-    local owner=
-    local repo=
-    local charts_repo_url=
+    local version="${CRA_VERSION:=$DEFAULT_CHART_RELEASER_VERSION}"
+    local config="${CRA_CONFIG:=}"
+    local charts_dir="${CRA_CHARTS_DIR:=charts}"
+    local owner="${CRA_OWNER:=}"
+    local repo="${CRA_REPO:=}"
+    local charts_repo_url="${CRA_CHARTS_REPO_URL:=}"
 
     parse_command_line "$@"
 


### PR DESCRIPTION
Hello,

I have a use case where I want one repo push changes to a central git repo (i.e. the chart in a repo, and the index in another repo). 

It's not possible to do that because there is no way to set vars for chart-releaser-action.

This is a small change to make it possible.

Thanks.