### PR TITLE
Fixes an issue with chart_depth when charts_dir is .

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -225,7 +225,7 @@ lookup_changed_charts() {
     local changed_files
     changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
 
-    local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | wc -l) + 1 ))
+    local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1 ))
     local fields="1-${depth}"
 
     cut -d '/' -f "$fields" <<< "$changed_files" | uniq | filter_charts


### PR DESCRIPTION
Fixes an issue with `depth` when `charts_dir` is set to `.`

This is the same fix identified in PR #62, and contains @montek 's [update recommendation](https://github.com/helm/chart-releaser-action/pull/62#pullrequestreview-605848446), as it seems the PR has become stale.

Closes issue #61 and PR #62.