### PR TITLE
Support actions triggered by a tag

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -226,7 +226,7 @@ install_chart_releaser() {
 lookup_latest_tag() {
     git fetch --tags > /dev/null 2>&1
 
-    if ! git describe --tags --abbrev=0 2> /dev/null; then
+    if ! git describe --tags --abbrev=0 HEAD~ 2> /dev/null; then
         git rev-list --max-parents=0 --first-parent HEAD
     fi
 }


### PR DESCRIPTION
helm/chart-releaser-action does not work on actions triggered by a tag because the `lookup_changed_charts` will never find differences in the charts. The problem is that `lookup_latest_tag` returns the tag that triggered the action, which is the current commit analyzed by `lookup_changed_charts`.

This simple solution skips the current (tagged) commit when searching for tags.

This is currently working for me. Others have requested it as well (https://github.com/helm/chart-releaser-action/issues/60).

Any feedback appreciated. Thanks