### PR TITLE
fix: cache directory path always in PATH env

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -193,10 +193,10 @@ install_chart_releaser() {
         curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$version/chart-releaser_${version#v}_linux_amd64.tar.gz"
         tar -xzf cr.tar.gz -C "$cache_dir"
         rm -f cr.tar.gz
-
-        echo 'Adding cr directory to PATH...'
-        export PATH="$cache_dir:$PATH"
     fi
+
+    echo 'Adding cr directory to PATH...'
+    export PATH="$cache_dir:$PATH"
 }
 
 lookup_latest_tag() {


### PR DESCRIPTION
Currently, only when the `cr` is installed the PATH env is updated with the cache directory, resulting in a working behavior for the first time but in consequents runs in the following error:
```
Looking up latest tag...
Discovering changed charts since 'test-0.0.8'...
Packaging chart 'charts/test'...
/tmp/_work/B5Gz2/_actions/helm/chart-releaser-action/v1.2.1/cr.sh: line 243: cr: command not found
Error: Process completed with exit code 127.
```

This might not be a problem in stateless runners since there the `cr` is always installed, but for stateful ones, its easy to replicate. 