### PR TITLE
docs: Add prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 
 1. A GitHub repo containing a directory with your Helm charts (eg: `/charts`)
 1. A GitHub branch called `gh-pages` to store the published charts. See `charts_repo_url` for alternatives
+1. In your repo, go to Settings/Pages. Change the `Source` `Branch` to `gh-pages`.
 1. Create a workflow `.yml` file in your `.github/workflows` directory. An [example workflow](#example-workflow) is available below.
   For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 
 ### Pre-requisites
 
-1. A GitHub repo containing a directory with your Helm charts (eg: `/charts`)
-1. A GitHub branch called `gh-pages` to store the published charts. See `charts_repo_url` for alternatives
+1. A GitHub repo containing a directory with your Helm charts (default is a folder named `/charts`, if you want to 
+maintain your charts in a different directory, you must include a `charts_dir` input in the workflow).
+1. A GitHub branch called `gh-pages` to store the published charts. See `charts_repo_url` for alternatives.
 1. In your repo, go to Settings/Pages. Change the `Source` `Branch` to `gh-pages`.
 1. Create a workflow `.yml` file in your `.github/workflows` directory. An [example workflow](#example-workflow) is available below.
   For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)
@@ -63,7 +64,7 @@ jobs:
 ```
 
 This uses [@helm/chart-releaser-action](https://www.github.com/helm/chart-releaser-action) to turn your GitHub project into a self-hosted Helm chart repo.
-It does this – during every push to `main` – by checking each chart in your project, and whenever there's a new chart version, creates a corresponding [GitHub release](https://help.github.com/en/github/administering-a-repository/about-releases) named for the chart version, adds Helm chart artifacts to the release, and creates or updates an `index.yaml` file with metadata about those releases, which is then hosted on GitHub Pages
+It does this – during every push to `main` – by checking each chart in your project, and whenever there's a new chart version, creates a corresponding [GitHub release](https://help.github.com/en/github/administering-a-repository/about-releases) named for the chart version, adds Helm chart artifacts to the release, and creates or updates an `index.yaml` file with metadata about those releases, which is then hosted on GitHub Pages. You do not need an `index.yaml` file in `main` at all because it is managed in the `gh-pages` branch.
 
 #### Example using custom config
 


### PR DESCRIPTION
I found that there were some instructions missing from the prerequisites that weren't very straightforward. Also added some notes about where and how `index.yaml` is maintained.