### PR TITLE
Allow to mark the published github release as latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `charts_dir`: The charts directory
 - `charts_repo_url`: The GitHub Pages URL to the charts repo (default: `https://<owner>.github.io/<project>`)
 - `skip_packaging`: This option, when populated, will skip the packaging step. This allows you to do more advanced packaging of your charts (for example, with the `helm package` command) before this action runs. This action will only handle the indexing and publishing steps.
+- `mark_as_latest`: This option, when not set to `false`, will mark the created GitHub release as 'latest'.
 
 ### Environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
   skip_packaging:
     description: "skip the packaging option (do your custom packaging before running this action"
     required: false
+  mark_as_latest:
+    description: Mark the created GitHub release as 'latest'
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -59,6 +63,10 @@ runs:
 
         if [[ -n "${{ inputs.skip_packaging }}" ]]; then
             args+=(--skip-packaging "${{ inputs.skip_packaging }}")
+        fi
+
+        if [[ -n "${{ inputs.mark_as_latest }}" ]]; then
+            args+=(--mark-as-latest "${{ inputs.mark_as_latest }}")
         fi
 
         "$GITHUB_ACTION_PATH/cr.sh" "${args[@]}"

--- a/cr.sh
+++ b/cr.sh
@@ -33,6 +33,7 @@ Usage: $(basename "$0") <options>
     -n, --install-dir        The Path to install the cr tool
     -i, --install-only       Just install the cr tool
     -s, --skip-packaging     Skip the packaging step (run your own packaging before using the releaser)
+    -l, --mark-as-latest     Mark the created GitHub release as 'latest' (default: true)
 EOF
 }
 
@@ -45,6 +46,7 @@ main() {
     local install_dir=
     local install_only=
     local skip_packaging=
+    local mark_as_latest=true
 
     parse_command_line "$@"
 
@@ -171,6 +173,12 @@ parse_command_line() {
                     shift
                 fi
                 ;;
+            -l|--mark-as-latest)
+                if [[ -n "${2:-}" ]]; then
+                    mark_as_latest="$2"
+                    shift
+                fi
+                ;;
             *)
                 break
                 ;;
@@ -271,6 +279,9 @@ release_charts() {
     local args=(-o "$owner" -r "$repo" -c "$(git rev-parse HEAD)")
     if [[ -n "$config" ]]; then
         args+=(--config "$config")
+    fi
+    if [[ "$mark_as_latest" = false ]]; then
+        args+=(--make-release-latest false)
     fi
 
     echo 'Releasing charts...'


### PR DESCRIPTION
Implements this option https://github.com/helm/chart-releaser/blob/ee26f50ce93ca23920dc1ce93e677665ce65a46e/README.md?plain=1#L88.

Required for https://github.com/nextcloud/all-in-one/pull/2034