### PR TITLE
Remove deprecated `charts_repo_url` option in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 
 1. A GitHub repo containing a directory with your Helm charts (default is a folder named `/charts`, if you want to
    maintain your charts in a different directory, you must include a `charts_dir` input in the workflow).
-1. A GitHub branch called `gh-pages` to store the published charts. See `charts_repo_url` for alternatives.
+1. A GitHub branch called `gh-pages` to store the published charts.
 1. In your repo, go to Settings/Pages. Change the `Source` `Branch` to `gh-pages`.
 1. Create a workflow `.yml` file in your `.github/workflows` directory. An [example workflow](#example-workflow) is available below.
    For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)


### PR DESCRIPTION
As `charts_repo_url` option has been deprecated: https://github.com/helm/chart-releaser-action/pull/123, reference of `charts_repo_url` in `REAMDE.md` documentation should also be removed to prevent further usage.

For more information, follow: https://github.com/helm/chart-releaser-action/pull/123#issuecomment-1452649079, https://github.com/helm/chart-releaser-action/pull/123#issuecomment-1503020990

---
Updates: 2023.04.18

`mark_as_latest` option also seems to be deprecated too. Removed `mark_as_latest` in doc and codes as well.