### PR TITLE
Add --skip-upload input with latest helm/chart-releaser-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `charts_dir`: The charts directory
 - `skip_packaging`: This option, when populated, will skip the packaging step. This allows you to do more advanced packaging of your charts (for example, with the `helm package` command) before this action runs. This action will only handle the indexing and publishing steps.
 - `skip_existing`: Skip package upload if release/tag already exists
+- `skip_upload`: This option, when populated, will skip the upload step. This allows you to do more advanced uploading of your charts (for exemple with OCI based repositories) which doen't require the `index.yaml`.
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 - `packages_with_index`: When you set this to `true`, it will upload chart packages directly into publishing branch.
 - `pages_branch`: Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   skip_existing:
     description: "Skip package upload if release exists"
     required: false
+  skip_upload:
+    description: "Skip package upload"
+    required: false
   mark_as_latest:
     description: Mark the created GitHub release as 'latest'
     required: false
@@ -84,6 +87,10 @@ runs:
 
         if [[ -n "${{ inputs.skip_existing }}" ]]; then
             args+=(--skip-existing "${{ inputs.skip_existing }}")
+        fi
+
+        if [[ -n "${{ inputs.skip_upload }}" ]]; then
+            args+=(--skip-upload "${{ inputs.skip_upload }}")
         fi
 
         if [[ -n "${{ inputs.mark_as_latest }}" ]]; then

--- a/cr.sh
+++ b/cr.sh
@@ -35,6 +35,7 @@ Usage: $(basename "$0") <options>
     -i, --install-only            Just install the cr tool
     -s, --skip-packaging          Skip the packaging step (run your own packaging before using the releaser)
         --skip-existing           Skip package upload if release exists
+        --skip-upload             Skip package upload, just create the release. Not needed in case of OCI upload.
     -l, --mark-as-latest          Mark the created GitHub release as 'latest' (default: true)
         --packages-with-index     Upload chart packages directly into publishing branch
 EOF
@@ -50,6 +51,7 @@ main() {
   local install_only=
   local skip_packaging=
   local skip_existing=
+  local skip_upload=
   local mark_as_latest=true
   local packages_with_index=false
   local pages_branch=
@@ -198,6 +200,12 @@ parse_command_line() {
         shift
       fi
       ;;
+    --skip-upload)
+      if [[ -n "${2:-}" ]]; then
+          skip_upload="$2"
+          shift
+      fi
+      ;;
     -l | --mark-as-latest)
       if [[ -n "${2:-}" ]]; then
         mark_as_latest="$2"
@@ -328,6 +336,11 @@ release_charts() {
 }
 
 update_index() {
+  if [[ -n "$skip_upload" ]]; then
+    echo "Skipping index upload..."
+    return
+  fi
+
   local args=(-o "$owner" -r "$repo" --push)
   if [[ -n "$config" ]]; then
     args+=(--config "$config")


### PR DESCRIPTION
# Description

This PR introduces a new feature that allows skipping the `upload_index` parts in this action. The main motivation behind this change is to enable the use of OCI-based repositories for Helm with the Github Container Registry without managing the upload process of the `index.yaml` file.

Changes Made:

- Updated `README.md`: Added information about the new `--skip-upload` option and its purpose.

- Updated `action.yaml`: Added the skip_upload input parameter to the action file.

- Updated `cr.sh`:

    * Added the `--skip-upload` option to the script's usage information.
    * Modified the `main()` function to respect the skip_upload option.
    * ~~Ensured that `update_index` is only called if the `skip_upload` option is not set.~~ This is handled directly in the `update_index` function now.
    * Handled the `skip_upload` variable properly and passed it as an argument when calling `update_index`.
