### PR TITLE
Remove `charts_repo_url` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `version`: The chart-releaser version to use (default: v1.4.1)
 - `config`: Optional config file for chart-releaser. For more information on the config file, see the [documentation](https://github.com/helm/chart-releaser#config-file)
 - `charts_dir`: The charts directory
-- `charts_repo_url`: The GitHub Pages URL to the charts repo (default: `https://<owner>.github.io/<project>`)
 - `skip_packaging`: This option, when populated, will skip the packaging step. This allows you to do more advanced packaging of your charts (for example, with the `helm package` command) before this action runs. This action will only handle the indexing and publishing steps.
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 
@@ -80,7 +79,6 @@ It does this – during every push to `main` – by checking each chart in your 
   with:
     charts_dir: charts
     config: cr.yaml
-    charts_repo_url: xxxxxx
   env:
     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```


### PR DESCRIPTION
`charts_repo_url` is no longer supported, so should be removed from readme