### PR TITLE
Add option to exclude tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 - `packages_with_index`: When you set this to `true`, it will upload chart packages directly into publishing branch.
 - `pages_branch`: Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)
+- `exclude_tags`: Tags matching this glob are excluded when looking for the latest release
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,8 @@ inputs:
     required: false
   pages_branch:
     description: "Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)"
+  exclude_tags:
+    description: "Tags matching this glob are excluded when looking for the latest release"
     required: false
 outputs:
   changed_charts:
@@ -96,6 +98,10 @@ runs:
 
         if [[ -n "${{ inputs.pages_branch }}" ]]; then
             args+=(--pages-branch "${{ inputs.pages_branch }}")
+        fi
+        
+        if [[ -n "${{ inputs.exclude_tags }}" ]]; then
+            args+=(--exclude-tags "${{ inputs.exclude_tags }}")
         fi
 
         "$GITHUB_ACTION_PATH/cr.sh" "${args[@]}"


### PR DESCRIPTION
The current code for `lookup_latest_tag` finds the latest tag, whether it was generated by helm or not. This option allows excluding a certain pattern of tags. e.g. `v*` to exclude version tags.