### PR TITLE
Bump `actions/checkout` action `v2` -> `v3`

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,7 +18,7 @@ jobs:
       statuses: none
     name: Install chart-releaser and test presence in path
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install chart-releaser
       uses: ./
       with:
@@ -49,7 +49,7 @@ jobs:
       statuses: none
     name: Install chart-releaser and run it
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install chart-releaser
       uses: ./
       env:


### PR DESCRIPTION
Fix CI warning:
```
The following actions uses node12 which is deprecated and will be forced to run
on node16: actions/checkout@v2. For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```
See e.g.
https://github.com/helm/chart-releaser-action/actions/runs/6076076359
![screen](https://github.com/helm/chart-releaser-action/assets/39981869/b0db30b7-5bac-4d87-93d7-692fb8208ebe)
