### PR TITLE
Fix `--packages-with-index` always being set

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -311,7 +311,7 @@ release_charts() {
   if [[ -n "$config" ]]; then
     args+=(--config "$config")
   fi
-  if [[ -n "$packages_with_index" ]]; then
+  if [[ "$packages_with_index" = true ]]; then
     args+=(--packages-with-index --push --skip-existing)
   elif [[ -n "$skip_existing" ]]; then
     args+=(--skip-existing)
@@ -332,7 +332,7 @@ update_index() {
   if [[ -n "$config" ]]; then
     args+=(--config "$config")
   fi
-  if [[ -n "$packages_with_index" ]]; then
+  if [[ "$packages_with_index" = true ]]; then
     args+=(--packages-with-index --index-path .)
   fi
   if [[ -n "$pages_branch" ]]; then


### PR DESCRIPTION
Since `$packages_with_index` defaults to `false` earlier in `main`, `-n` will always be true and thus add the `--packages-with-index` flag.