### PR TITLE
Optionally use chart-testing to detect changed charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `changed_charts`: A comma-separated list of charts that were released on this run. Will be an empty string if no updates were detected, will be unset if `--skip_packaging` is used: in the latter case your custom packaging step is responsible for setting its own outputs if you need them.
 - `chart_version`: The version of the most recently generated charts; will be set even if no charts have been updated since the last run.
 
+### Changed charts detection
+
+If [chart-testing](https://github.com/helm/chart-testing) is present in the PATH, it will be used to detect changed charts using `ct list-changed` command.
+If not present, it will fallback to a simpler method of detection using `git diff`.
+
 ### Environment variables
 
 - `CR_TOKEN` (required): The GitHub token of this repository (`${{ secrets.GITHUB_TOKEN }}`)
@@ -65,6 +70,13 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      # optional, setup chart-testing for changed charts detection
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.5.0
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/cr.sh
+++ b/cr.sh
@@ -305,13 +305,18 @@ filter_charts() {
 lookup_changed_charts() {
   local commit="$1"
 
-  local changed_files
-  changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
+  if command -v ct >/dev/null; then
+    echo Using ct to detect changed charts
+    ct list-changed --since "$commit" --chart-dirs "$charts_dir"
+  else
+    local changed_files
+    changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
 
-  local depth=$(($(tr "/" "\n" <<<"$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1))
-  local fields="1-${depth}"
+    local depth=$(($(tr "/" "\n" <<<"$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1))
+    local fields="1-${depth}"
 
-  cut -d '/' -f "$fields" <<<"$changed_files" | uniq | filter_charts
+    cut -d '/' -f "$fields" <<<"$changed_files" | uniq | filter_charts
+  fi
 }
 
 package_chart() {


### PR DESCRIPTION
this optionally use chart-testing (ct list-changed) to detect changed charts.

As of today, it's not much different than the implementation in shell, but it would be improved by PR in chart-testing repo such as consideration of .helmignore 