### PR TITLE
Add pages-index-path flag to chart release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 - `packages_with_index`: When you set this to `true`, it will upload chart packages directly into publishing branch.
 - `pages_branch`: Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)
+- `index_path`: Path to index file (default .cr-index/index.yaml)
+- `pages_index_path`: The GitHub pages index path (default index.yaml)
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,12 @@ inputs:
   pages_branch:
     description: "Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)"
     required: false
+  index_path:
+    description: "Path to index file (default .cr-index/index.yaml)"
+    required: false
+  pages_index_path:
+    description: "The GitHub pages index path (default index.yaml)"
+    required: false
 outputs:
   changed_charts:
     description: "A comma-separated list of charts that were released on this run. Will be an empty string if no updates were detected, will be unset if `--skip_packaging` is used: in the latter case your custom packaging step is responsible for setting its own outputs if you need them."
@@ -118,6 +124,14 @@ runs:
 
         if [[ -n "${{ inputs.pages_branch }}" ]]; then
             args+=(--pages-branch "${{ inputs.pages_branch }}")
+        fi
+
+        if [[ -n "${{ inputs.index_path }}" ]]; then
+            args+=(--index-path "${{ inputs.index_path }}")
+        fi
+
+        if [[ -n "${{ inputs.pages_index_path }}" ]]; then
+            args+=(--pages-index-path "${{ inputs.pages_index_path }}")
         fi
 
         "$GITHUB_ACTION_PATH/cr.sh" "${args[@]}"

--- a/cr.sh
+++ b/cr.sh
@@ -38,6 +38,8 @@ Usage: $(basename "$0") <options>
         --skip-upload             Skip package upload, just create the release. Not needed in case of OCI upload.
     -l, --mark-as-latest          Mark the created GitHub release as 'latest' (default: true)
         --packages-with-index     Upload chart packages directly into publishing branch
+        --index-path              Path to index file (default .cr-index/index.yaml)
+        --pages-index-path        The GitHub pages index path (default index.yaml)
 EOF
 }
 
@@ -55,6 +57,8 @@ main() {
   local mark_as_latest=true
   local packages_with_index=false
   local pages_branch=
+  local index_path=
+  local pages_index_path=
 
   parse_command_line "$@"
 
@@ -218,6 +222,18 @@ parse_command_line() {
         shift
       fi
       ;;
+    --pages-index-path)
+      if [[ -n "${2:-}" ]]; then
+        pages_index_path="$2"
+        shift
+      fi
+      ;;
+    --index-path)
+      if [[ -n "${2:-}" ]]; then
+        index_path="$2"
+        shift
+      fi
+      ;;
     *)
       break
       ;;
@@ -350,6 +366,12 @@ update_index() {
   fi
   if [[ -n "$pages_branch" ]]; then
     args+=(--pages-branch "$pages_branch")
+  fi
+  if [[ -n "$index_path" ]]; then
+    args+=(--index-path "$index_path")
+  fi  
+  if [[ -n "$pages_index_path" ]]; then
+    args+=(--pages-index-path "$pages_index_path")
   fi
 
   echo 'Updating charts repo index...'


### PR DESCRIPTION
To customize the path for the index.yaml generated by the chart release action, both index-path and pages-index-path flags are added.

Those flags are supported by the `cr index`:
```
cr help index | grep "index-path"
  -i, --index-path string              Path to index file (default ".cr-index/index.yaml")
      --pages-index-path string        The GitHub pages index path (default "index.yaml")
```

Closes https://github.com/helm/chart-releaser-action/issues/183