### PR TITLE
Update checkout action to v4 tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0


### PR DESCRIPTION
The example workflow in the readme uses a step `actions/checkout` with version v3, this version uses Node.js 16 which is deprecated, the following message added to the run: 

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3
```

 - An example of a run with v3: https://github.com/maarten-blokker/helm/actions/runs/8711668277
 - An example of a run after updating to v4: https://github.com/maarten-blokker/helm/actions/runs/8711740405/job/23896519184