### PR TITLE
Write chart_version only if latest_tag is defined

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -96,9 +96,12 @@ main() {
         IFS=,
         echo "${changed_charts[*]}"
       )" >changed_charts.txt
+
+      echo "chart_version=${latest_tag}" >chart_version.txt
     else
       echo "Nothing to do. No chart changes detected."
       echo "changed_charts=" >changed_charts.txt
+      echo "chart_version=" >chart_version.txt
     fi
   else
     install_chart_releaser
@@ -107,8 +110,6 @@ main() {
     release_charts
     update_index
   fi
-
-  echo "chart_version=${latest_tag}" >chart_version.txt
 
   popd >/dev/null
 }


### PR DESCRIPTION
The chart_version output was written regardless of whether the latest_tag variable was defined. The latest_tag variable is only defined if skip_packaging is not set. This leads to issue #171.

Setting skip_packaging implies that an external process takes care of packaging the chart and setting the chart version. There is thus no need to write the chart_version output as it should already be known.

Closes #171