### PR TITLE
Remove redundant step from example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:


### PR DESCRIPTION
Step `Install Helm` is not needed in the example workflow and might confuse users.