### PR TITLE
Bump actions/checkout from v3 to v4 in example action in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Hello 👋 

Simple change in the readme.md, to reflect the deprecation of actions/checkout@v3
The change was made in the test_action in a917fd1, so I assume it works well.