### PR TITLE
Skip upload for release step

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -85,7 +85,7 @@ main() {
       for chart in "${changed_charts[@]}"; do
         if [[ -d "$chart" ]]; then
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm dependencies build "$chart"
+          # helm dependencies build "$chart"
           package_chart "$chart"
         else
           echo "Nothing to do. No chart changes detected."

--- a/cr.sh
+++ b/cr.sh
@@ -316,7 +316,7 @@ package_chart() {
 
 release_charts() {
   if [[ -n "$skip_upload" ]]; then
-    echo "Skipping index upload..."
+    echo "Skipping release upload..."
     return
   fi
   

--- a/cr.sh
+++ b/cr.sh
@@ -315,6 +315,11 @@ package_chart() {
 }
 
 release_charts() {
+  if [[ -n "$skip_upload" ]]; then
+    echo "Skipping index upload..."
+    return
+  fi
+  
   local args=(-o "$owner" -r "$repo" -c "$(git rev-parse HEAD)")
   if [[ -n "$config" ]]; then
     args+=(--config "$config")

--- a/cr.sh
+++ b/cr.sh
@@ -84,6 +84,7 @@ main() {
 
       for chart in "${changed_charts[@]}"; do
         if [[ -d "$chart" ]]; then
+          helm dependencies build "$chart"
           package_chart "$chart"
         else
           echo "Nothing to do. No chart changes detected."

--- a/cr.sh
+++ b/cr.sh
@@ -84,6 +84,7 @@ main() {
 
       for chart in "${changed_charts[@]}"; do
         if [[ -d "$chart" ]]; then
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependencies build "$chart"
           package_chart "$chart"
         else


### PR DESCRIPTION
Resolve the issue with upload from release_charts step when --skip-upload passed.

Upload from release_charts creates an issue in case you wish to use cr tool for packaging only (for example when you use OCI repository).

Using this fix for some month without any issue.