### PR TITLE
Add skip_release flag to bypass GitHub releases and tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `skip_packaging`: This option, when populated, will skip the packaging step. This allows you to do more advanced packaging of your charts (for example, with the `helm package` command) before this action runs. This action will only handle the indexing and publishing steps.
 - `skip_existing`: Skip package upload if release/tag already exists
 - `skip_upload`: This option, when populated, will skip the upload step. This allows you to do more advanced uploading of your charts (for exemple with OCI based repositories) which doen't require the `index.yaml`.
+- `skip_release`: Skip creating GitHub release and tag, only push artifacts to pages branch.
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 - `packages_with_index`: When you set this to `true`, it will upload chart packages directly into publishing branch.
 - `pages_branch`: Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
   skip_upload:
     description: "Skip package upload"
     required: false
+  skip_release:
+    description: "Skip creating GitHub release and tag, only push artifacts to pages branch"
+    required: false
+    default: false
   mark_as_latest:
     description: Mark the created GitHub release as 'latest'
     required: false
@@ -106,6 +110,10 @@ runs:
 
         if [[ -n "${{ inputs.skip_upload }}" ]]; then
             args+=(--skip-upload "${{ inputs.skip_upload }}")
+        fi
+
+        if [[ -n "${{ inputs.skip_release }}" ]]; then
+            args+=(--skip-release "${{ inputs.skip_release }}")
         fi
 
         if [[ -n "${{ inputs.mark_as_latest }}" ]]; then


### PR DESCRIPTION
Added a new `skip_release` flag that allows users to bypass GitHub release and tag creation while still publishing chart artifacts to the pages branch.

Some workflows only need to publish chart artifacts without managing GitHub releases and tags. Especially for monorepos.

Example:

```yaml
- name: Run chart-releaser
  uses: helm/chart-releaser-action@v1.6.0
  with:
    skip_release: true
    packages_with_index: true
  env:
    CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```

